### PR TITLE
Allow newer versions of certbot in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-acme==2.11.0
-certbot==2.11.0
+acme>=2.11.0
+certbot>=2.11.0
 certifi==2024.8.30
 cffi==1.17.0
 charset-normalizer==3.3.2

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup, find_packages
 
 
 install_requires = [
-    "acme==2.11.0",
-    "certbot==2.11.0",
+    "acme>=2.11.0",
+    "certbot>=2.11.0",
     "certifi==2024.8.30",
     "cffi==1.17.0",
     "charset-normalizer==3.3.2",


### PR DESCRIPTION
This commit makes the `certbot` and `acme` requirement more liberal. I have tested it to work on version 3.0.1 of both.

You could also consider doing the same for other requirements or even removing them, but I do not have the expertise on that at the moment.